### PR TITLE
Changed redelegate value

### DIFF
--- a/src/types/Context.ts
+++ b/src/types/Context.ts
@@ -14,7 +14,7 @@ const defaultGasLimits: GasLimits<CosmosFeeTable> = {
     send: 80_000,
     transfer: 160_000,
     delegate: 160_000,
-    redelegate: 240_000,
+    redelegate: 245_262,
     undelegate: 160_000,
     withdrawDelegatorReward: 160_000,
     setWithdrawAddress: 160_000,


### PR DESCRIPTION
The error: out of gas in location: WritePerByte; gasWanted: 240000, gasUsed: 245262: out of gas


The solution is to update the Gaslimits over 240,000 : const defaultGasLimits: GasLimits<CosmosFeeTable> 